### PR TITLE
Fixed problem with server closed sessions and optimized server response

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.voice/src/main/java/org/eclipse/smarthome/io/voice/internal/STTServiceKaldiRunnable.java
+++ b/bundles/io/org.eclipse.smarthome.io.voice/src/main/java/org/eclipse/smarthome/io/voice/internal/STTServiceKaldiRunnable.java
@@ -11,6 +11,8 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
+import ee.ioc.phon.netspeechapi.duplex.RecognitionEvent;
+import ee.ioc.phon.netspeechapi.duplex.RecognitionEventListener;
 import ee.ioc.phon.netspeechapi.duplex.WsDuplexRecognitionSession;
 
 import org.eclipse.smarthome.io.audio.AudioFormat;
@@ -26,7 +28,7 @@ import org.eclipse.smarthome.io.voice.STTListener;
  * @author Kelly Davis - Initial contribution and API
  *
  */
-public class STTServiceKaldiRunnable implements Runnable {
+public class STTServiceKaldiRunnable implements Runnable, RecognitionEventListener {
    /**
     * Boolean indicating if the thread is aborting
     */
@@ -59,6 +61,8 @@ public class STTServiceKaldiRunnable implements Runnable {
         this.audioSource = audioSource;
         this.sttListener = sttListener;
         this.recognitionSession = recognitionSession;
+
+        this.recognitionSession.addRecognitionEventListener(this);
     }
 
    /**
@@ -115,5 +119,19 @@ public class STTServiceKaldiRunnable implements Runnable {
     */
     public void abort() {
         this.isAborting = true;
+    }
+
+   /**
+    * {@inheritDoc}
+    */
+    public void onRecognitionEvent(RecognitionEvent recognitionEvent) {
+        // RecognitionEvent are ignored
+    }
+
+   /**
+    * {@inheritDoc}
+    */
+    public void onClose() {
+        this.abort();
     }
 }


### PR DESCRIPTION
Fixed problem observed by Andre in which the Runnable was not aware of the server closing the session and continued to send data despite the server indicating the session was closed. 

Fixed a second problem in which the orchestrator waited until the server closed the connection before saying its response instead of saying its response immediately upon obtaining the server's STT result.

Signed-off-by: Kelly Davis kdavis@mozilla.com
