### PR TITLE
Wrong split when the item label contains both lowercase and uppercase letters

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.voice/src/main/java/org/eclipse/smarthome/io/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/io/org.eclipse.smarthome.io.voice/src/main/java/org/eclipse/smarthome/io/voice/text/AbstractRuleBasedInterpreter.java
@@ -503,7 +503,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         if (name == null) {
             return parts;
         }
-        String[] split = name.replaceAll("\\.", "").split("(?<!^)(?=[A-Z])|_|\\s+");
+        String[] split = name.toLowerCase().replaceAll("\\.", "").split("(?<!^)(?=[A-Z])|_|\\s+");
         for (int i = 0; i < split.length; i++) {
             String part = split[i].trim();
             if (part.length() > 1) {


### PR DESCRIPTION
When we have an item written with both lower and uppercase letters, the regex splits the array in every uppercase occurrence.

For example, for the word: "WeMo Switch", the array will be: [We,Mo,,Switch]
But if the word has only lowercases "wemo switch", it splits correctly, and the array will be [ wemo, switch]
